### PR TITLE
Fix: Input Field

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,9 +12,9 @@ function App() {
   return (
     <>
       <NavBar />
-      <div className="hero-container">
+      {/* <div className="hero-container">
         <img src={heroImage} alt="" aria-hidden="true" className="hero-image" />
-      </div>
+      </div> */}
       <form>
         {/* --- Buttons --- */}
 
@@ -71,7 +71,7 @@ function App() {
           type="text"
           id="email"
         />
-        <TextInput formLabel="Password" placeholder="skriv.." type="password" />
+        <TextInput formLabel="Password" placeholder="skriv.." type="password" subText="Lösenordet måste vara minst 8 tecken långt" required={true} optional={true} />
       </form>
       <TabSlider
         tabs={["Företag", "Studenter"]}

--- a/client/src/components/Forms/Checkboxes/Checkbox.module.css
+++ b/client/src/components/Forms/Checkboxes/Checkbox.module.css
@@ -1,7 +1,6 @@
 .checkbox {
     display: inline-flex;
     align-items: center;
-    font-family: Inter;
     font-size: 13px;
     font-style: normal;
     font-weight: 400;

--- a/client/src/components/Forms/InputFields/TextInput.jsx
+++ b/client/src/components/Forms/InputFields/TextInput.jsx
@@ -6,7 +6,7 @@ export default function TextInput({ formLabel, placeholder, id, type, subText, r
   const inputId = id ?? generatedId;
 
   const label = (
-    <label htmlFor={inputId} className={styles.inputLabel}>
+    <label htmlFor={inputId} className={styles.inputLabel} >
       {formLabel}
       {required && <span aria-hidden="true" style={{ color: "grey" }}> *</span>}
       {optional && <span aria-hidden="true" className={styles.optional}>(optional)</span>}
@@ -27,6 +27,8 @@ export default function TextInput({ formLabel, placeholder, id, type, subText, r
         name={inputId}
         placeholder={placeholder}
         className={styles.textInput}
+        required={required}
+        aria-required={required}
       />
     </div>
   );

--- a/client/src/components/Forms/InputFields/TextInput.jsx
+++ b/client/src/components/Forms/InputFields/TextInput.jsx
@@ -1,13 +1,26 @@
 import { useId } from "react";
 import styles from "./TextInput.module.css";
 
-export default function TextInput({ formLabel, placeholder, id, type }) {
-  const inputId = id ?? useId();
+export default function TextInput({ formLabel, placeholder, id, type, subText, required = false, optional = false }) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+
+  const label = (
+    <label htmlFor={inputId} className={styles.inputLabel}>
+      {formLabel}
+      {required && <span aria-hidden="true" style={{ color: "grey" }}> *</span>}
+      {optional && <span aria-hidden="true" className={styles.optional}>(optional)</span>}
+    </label>
+  );
+
   return (
-    <>
-      <label htmlFor={inputId} className={styles.textForm}>
-        {formLabel}
-      </label>
+    <div className={styles.textForm}>
+      {subText ? (
+        <div className={styles.labelSubtext}>
+          {label}
+          <small className={styles.subText}>{subText}</small>
+        </div>
+      ) : label}
       <input
         type={type}
         id={inputId}
@@ -15,6 +28,6 @@ export default function TextInput({ formLabel, placeholder, id, type }) {
         placeholder={placeholder}
         className={styles.textInput}
       />
-    </>
+    </div>
   );
 }

--- a/client/src/components/Forms/InputFields/TextInput.module.css
+++ b/client/src/components/Forms/InputFields/TextInput.module.css
@@ -1,7 +1,19 @@
-.textForm{
+.textForm {
     display: flex;
     flex-direction: column;
+    gap: 0.5rem;
+}
+
+.labelSubtext {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+.inputLabel {
     text-align: left;
+    color: black;
+    font-size: 1rem;
+    font-weight: 700;
 }
 .textInput {
     background-color: white;
@@ -9,4 +21,19 @@
     border-radius: 8px;
     border: 2px solid gray;
     width: 100%;
+}
+
+.subText {
+    text-align: left;
+    margin: 0;
+    align-self: flex-start;
+    gap: 0;
+    font-size: .93rem;
+}
+
+.optional {
+    font-size: 1rem;
+    color: grey;
+    font-style: italic;
+    font-weight: 400;
 }

--- a/client/src/components/Forms/InputFields/TextInput.module.css
+++ b/client/src/components/Forms/InputFields/TextInput.module.css
@@ -27,7 +27,6 @@
     text-align: left;
     margin: 0;
     align-self: flex-start;
-    gap: 0;
     font-size: .93rem;
 }
 


### PR DESCRIPTION
Updated TextInput component to match wireframe styling (font sizes may eventually need to be changed, I used the measurements in the wireframes, but they feel a bit large to me). Also updated the component to take subtext, optional, and required props so that we can more easily customize the labels and don't need to create additional components for those fields. 